### PR TITLE
Remove description root property, and rename specification_version and specification_source

### DIFF
--- a/plugins/specification/1.0/README.md
+++ b/plugins/specification/1.0/README.md
@@ -55,7 +55,6 @@ This specification allows for the standardization of metadata for WordPress plug
 	  "screenshots": ""
 	},
 	"short_description": "A WordPress plugin for drag and drop 3D content creation compatible with most XR devices.",
-	"description": "A WordPress plugin for publishing XR content with support for WebXR and popular glTF Extensions.",
 	"download_link": "https://updater.sxp.digital/xr-publisher.zip",
 	"screenshots": [],
 	"tags": {
@@ -87,8 +86,8 @@ This specification allows for the standardization of metadata for WordPress plug
 	"preview_link": "https://xrpublisher.com/demo",
 	"repository_url": "https://github.com/antpb/xr-publisher",
 	"spec_meta": {
-		"specification-version": "1.0",
-		"specification-source": "aspiprepress"
+		"specification_version": "1.0",
+		"specification_source": "aspiprepress"
 	  }  
   }
 ```

--- a/plugins/specification/1.0/examples/full.json
+++ b/plugins/specification/1.0/examples/full.json
@@ -33,7 +33,6 @@
 	  "screenshots": ""
 	},
 	"short_description": "A WordPress plugin for drag and drop 3D content creation compatible with most XR devices.",
-	"description": "A WordPress plugin for publishing XR content with support for WebXR and popular glTF Extensions.",
 	"download_link": "https://updater.sxp.digital/xr-publisher.zip",
 	"screenshots": [],
 	"tags": {
@@ -65,7 +64,7 @@
 	"preview_link": "https://xrpublisher.com/demo",
 	"repository_url": "https://github.com/antpb/xr-publisher",
 	"spec_meta": {
-		"specification-version": "1.0",
-		"specification-source": "aspiprepress"
+		"specification_version": "1.0",
+		"specification_source": "aspiprepress"
 	  }  
   }

--- a/plugins/specification/1.0/examples/full.json
+++ b/plugins/specification/1.0/examples/full.json
@@ -39,6 +39,10 @@
 	  "tag1": "metaverse",
 	  "tag2": "virtual reality"
 	},
+	"banners": {
+		"high": "https://pub-2ef6bc2ae372488daf94a858e2b752ac.r2.dev/antpb/xr-chess-block/banner-1500x620.jpg",
+		"low": "https://pub-2ef6bc2ae372488daf94a858e2b752ac.r2.dev/antpb/xr-chess-block/banner-1500x620.jpg"
+	},
 	"versions": {
 	  "2.0-alpha": "https://updater.sxp.digital/xr-publisher.zip"
 	},
@@ -65,6 +69,6 @@
 	"repository_url": "https://github.com/antpb/xr-publisher",
 	"spec_meta": {
 		"specification_version": "1.0",
-		"specification_source": "aspiprepress"
+		"specification_source": "aspirepress"
 	  }  
   }

--- a/plugins/specification/1.0/examples/minimal.json
+++ b/plugins/specification/1.0/examples/minimal.json
@@ -9,10 +9,16 @@
 	"last_updated": "2024-10-09 12:00pm GMT",
 	"added": "2024-10-09",
 	"short_description": "A WordPress plugin for drag and drop 3D content creation compatible with most XR devices.",
-	"description": "A WordPress plugin for publishing XR content with support for WebXR and popular glTF Extensions.",
+	"sections": {
+		"description": "A WordPress plugin for publishing XR content with support for WebXR and popular glTF Extensions.",
+		"installation": "",
+		"changelog": "",
+		"faq": "",
+		"screenshots": ""
+	},
 	"download_link": "https://updater.sxp.digital/xr-publisher.zip",
 	"spec_meta": {
-		"specification-version": "1.0",
-		"specification-source": "aspiprepress"
+		"specification_version": "1.0",
+		"specification_source": "aspiprepress"
 	}
 }

--- a/plugins/specification/1.0/schema/plugin.schema.json
+++ b/plugins/specification/1.0/schema/plugin.schema.json
@@ -116,10 +116,6 @@
 			"type": "string",
 			"maxLength": 150
 		},
-		"description": {
-			"type": "string",
-			"contentMediaType": "text/html"
-		},
 		"download_link": {
 			"$ref": "#/$defs/uriString"
 		},
@@ -242,19 +238,19 @@
 		"spec_meta": {
 			"type": "object",
 			"properties": {
-				"specification-version": {
+				"specification_version": {
 					"type": "string",
 					"pattern": "^\\d+\\.\\d+(\\.\\d+)?$",
 					"default": "1.0"
 				},
-				"specification-source": {
+				"specification_source": {
 					"type": "string",
 					"const": "aspiprepress"
 				}
 			},
 			"required": [
-				"specification-version",
-				"specification-source"
+				"specification_version",
+				"specification_source"
 			],
 			"additionalProperties": false
 		}
@@ -270,8 +266,8 @@
 		"last_updated",
 		"added",
 		"short_description",
-		"description",
-		"download_link"
+		"download_link",
+		"sections"
 	],
 	"additionalProperties": false
 }

--- a/plugins/specification/1.0/schema/plugin.schema.json
+++ b/plugins/specification/1.0/schema/plugin.schema.json
@@ -245,7 +245,7 @@
 				},
 				"specification_source": {
 					"type": "string",
-					"const": "aspiprepress"
+					"const": "aspirepress"
 				}
 			},
 			"required": [

--- a/plugins/specification/1.0/schema/plugin.sections.schema.json
+++ b/plugins/specification/1.0/schema/plugin.sections.schema.json
@@ -29,5 +29,8 @@
 		"contentMediaType": "text/html"
 	  }
 	},
+	"required": [
+		"description"
+	],
 	"additionalProperties": false
   }


### PR DESCRIPTION
…tion-version and specification-source for consistency with other props

# Pull Request

## What changed?

This removes the description field from root as it should be in `sections`. Also this renames the `-` separated field names to `_`

## Why did it change?

Validation was breaking with proper json. This now makes it pass in my tool that uses the schema changes in this PR.


<img width="635" alt="fix_json_validation" src="https://github.com/user-attachments/assets/01a69a77-089e-495d-912f-6a6163e17ceb">


## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.